### PR TITLE
Add stuff to command to enable GUI

### DIFF
--- a/command.sh
+++ b/command.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
-docker run --name easycrypt -it --entrypoint "/usr/bin/bash" -v "$PWD:/home/easycrypt/workdir" agustinmista/easycrypt ||
-  docker start easycrypt && docker exec -it easycrypt /usr/bin/bash
+docker run --name easycrypt -e DISPLAY -it --entrypoint "/usr/bin/bash" -v /tmp/.X11-unix:/tmp/.X11-unix -v "$PWD:/home/easycrypt/workdir" agustinmista/easycrypt ||
+ docker start easycrypt && docker exec -e DISPLAY -it easycrypt /usr/bin/bash

--- a/doom-config/config.el
+++ b/doom-config/config.el
@@ -78,10 +78,6 @@
 ;; Disable Proof General's splash screen
 (setq proof-splash-enable nil)
 
-;; Disable annoying underlined text
-(add-hook 'proof-mode-hook
-  (lambda () (set-face-underline 'proof-locked-face nil)))
-
 ;; Skip some buffers
 (setq my-skippable-buffers '("*Messages*" "*scratch*" "*Help*"))
 


### PR DESCRIPTION
EasyCrypt is better with a GUI. This shares the running XServer dir and Display variable (in the command) to make the GUI available.